### PR TITLE
Ensure image visibility to channel for custom slash commands.

### DIFF
--- a/outgoing.js
+++ b/outgoing.js
@@ -6,10 +6,12 @@ module.exports = function (req, res, next) {
     var botPayload = {};
     if (!error && response.statusCode == 200) {
       botPayload.text = body;
+      botPayload.response_type = "in_channel";
       return res.status(200).json(botPayload);
     }
     else {
       botPayload.text = errimage;
+      botPayload.response_type = "ephemeral";
       return res.status(200).json(botPayload);
     }
   });


### PR DESCRIPTION
This ensures that all users in the channel can see messages from
InspiroBot.

However - error messages remain ephemeral.