### PR TITLE
Using the response URL from request

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,18 @@
 # InspiroBotSlack
 Slack integration with InspiroBot.me
 
-You can use the currently hosted Heroku App (For Outgoing WebHooks only) below or you can clone the repo yourself and upload the Node.js app to your own private webserver and configure somewhat like it is below:
+You can use the currently hosted Heroku App below or you can clone the repo yourself and upload the Node.js app to your own private webserver and configure somewhat like it is below:
 
 ##Outgoing WebHooks
-Within Slack Integrations choose Outgoing WebHooks and setup something similar to this:
+This feature only works in public channels. Within Slack Integrations choose Outgoing WebHooks and setup something similar to this:
 ![Image of Outgoing WebHooks Settings](http://i.imgur.com/fdLHTT4.png)
 
 Your efforts will result in one happy excited team.
 ![Image of Outgoing WebHooks in Action](http://i.imgur.com/9dhHzkP.png)
 
-##Incoming WebHook/Slash Command
-Within Slack Integration Choose Slash Command and setup something similar to this:
+##Slash Commands
+This works in all channels, within Slack Integration Choose Slash Command and setup something similar to this:
 ![Image of Slash Command Settings](http://i.imgur.com/MzReYB7.png)
-
-Then you can go to the Incoming WebHook Integration screen, set it up on any channel you would like and capture the URL, you'll need it in the format like: `/your/path/token` to be saved in the variable *INCOMING_WEBHOOK_PATH* like such on my Heroku application settings:
-![Image of Heroku Settings](http://i.imgur.com/4MD1i5b.png)
 
 Once it's configured, you can go ahead and test it out!
 ![Image of Incoming WebHooks in Action](http://i.imgur.com/YNeKT3l.png)

--- a/incoming.js
+++ b/incoming.js
@@ -7,9 +7,10 @@ module.exports = function (req, res, next) {
       channel : req.body.channel_id
     };
     if (!error && response.statusCode == 200) {
-      botPayload.text = "@" + req.body.user_name + ": " + req.body.command + " " + body;
+      botPayload.response_type = "in_channel";
+      botPayload.text = "<@" + req.body.user_id + ">: " + req.body.command + " " + body;
       // send Payload
-      send(botPayload, function (error, status, body) {
+      send(botPayload, req.body.response_url, function (error, status, body) {
         if (error) {
           return next(error);
         } else if (status !== 200) {
@@ -21,25 +22,22 @@ module.exports = function (req, res, next) {
       });
     }
     else {
-      botPayload.text = errimage;
+        botPayload.response_type = "ephemeral";
+        botPayload.text = errimage;
       return res.status(200).json(botPayload);
     }
   });
-}
+};
 
-function send (payload, callback) {
-  var path = process.env.INCOMING_WEBHOOK_PATH;
-  var uri = 'https://hooks.slack.com/services' + path;
-
+function send (payload, responseUrl, callback) {
   request({
-    uri: uri,
+    uri: responseUrl,
     method: 'POST',
     body: JSON.stringify(payload)
   }, function (error, response, body) {
     if (error) {
       return callback(error);
     }
-
     callback(null, response.statusCode, body);
   });
 }


### PR DESCRIPTION
- In reference to issue #3 I created, using the response_url instead of Webhook URL env param. This allows using slash commands in any DM.
- Setting response_type on the response to ensure visibility in DM's
- As a part of new Slack API `user_name` is being phased out, so using the `<@user_id>` to reference a name instead.